### PR TITLE
ci: fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: "*.svg"
+      - name: move them into docs
+        run: |
+          mkdir docs
+          mv *.svg docs/
       - name: upload badge to artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
       - name: make covarage badge
         run: |
           octocov badge coverage --out ${{ github.workspace }}/${{ steps.filename.outputs.filename }}
-      - run: ls
       - name: upload badge to artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           name: "*.svg"
       - name: upload badge to artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v2
         with:
           path: docs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifact
-          path: docs
+          name: "*.svg"
       - name: upload badge to artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: vim-themis
 
 on:
   push:
+    branches:
+      - "main"
     paths-ignore:
       - "README.md"
       - "doc/*.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
 
   upload-coverage-badge:
     runs-on: ubuntu-latest
-    if: github.ref == "refs/heads/main"
     needs: themis
     steps:
       - name: download artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
       - name: upload badge to artifact
         uses: actions/upload-artifact@v4
         with:
-          path: badge*.svg
+          path: badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
+          name: badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
           if-no-files-found: error
 
   upload-coverage-badge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: vim-themis
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - "README.md"
       - "doc/*.txt"
@@ -56,6 +54,7 @@ jobs:
       - name: make covarage badge
         run: |
           octocov badge coverage --out ${{ github.workspace }}/badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
+      - run: ls
       - name: upload badge to artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           name: artifact
           path: docs
       - name: upload badge to artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: vim-themis
 
 on:
   push:
-    branches:
-      - "main"
     paths-ignore:
       - "README.md"
       - "doc/*.txt"
@@ -60,6 +58,7 @@ jobs:
         run: |
           octocov badge coverage --out ${{ github.workspace }}/${{ steps.filename.outputs.filename }}
       - name: upload badge to artifact
+        if: github.ref == "refs/heads/main"
         uses: actions/upload-artifact@v4
         with:
           path: ${{ steps.filename.outputs.filename }}
@@ -68,6 +67,7 @@ jobs:
 
   upload-coverage-badge:
     runs-on: ubuntu-latest
+    if: github.ref == "refs/heads/main"
     needs: themis
     steps:
       - name: download artifacts
@@ -85,6 +85,7 @@ jobs:
 
   deploy-to-github-pages:
     runs-on: ubuntu-latest
+    if: github.ref == "refs/heads/main"
     needs: upload-coverage-badge
     permissions:
       pages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           octocov badge coverage --out ${{ github.workspace }}/${{ steps.filename.outputs.filename }}
       - name: upload badge to artifact
-        if: github.ref == "refs/heads/main"
         uses: actions/upload-artifact@v4
         with:
           path: ${{ steps.filename.outputs.filename }}
@@ -67,6 +66,7 @@ jobs:
 
   upload-coverage-badge:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: themis
     steps:
       - name: download artifacts
@@ -84,7 +84,7 @@ jobs:
 
   deploy-to-github-pages:
     runs-on: ubuntu-latest
-    if: github.ref == "refs/heads/main"
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: upload-coverage-badge
     permissions:
       pages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "*.svg"
+          pattern: "*.svg"
       - name: upload badge to artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,18 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.12.0
         with:
           repo: k1LoW/octocov
+      - name: create filename
+        id: filename
+        run: echo "filename=badge-${{ runner.os }}-$(test \"${{ matrix.neovim }}\" = \"true\" && echo neovim || echo vim )-${{ matrix.version }}.svg" >> "$GITHUB_OUTPUT"
       - name: make covarage badge
         run: |
-          octocov badge coverage --out ${{ github.workspace }}/badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
+          octocov badge coverage --out ${{ github.workspace }}/${{ steps.filename.outputs.filename }}
       - run: ls
       - name: upload badge to artifact
         uses: actions/upload-artifact@v4
         with:
-          path: badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
-          name: badge-${{ runner.os }}-$(test "${{ matrix.neovim }}" = "true" && echo "neovim" || echo "vim" )-${{ matrix.version }}.svg
+          path: ${{ steps.filename.outputs.filename }}
+          name: ${{ steps.filename.outputs.filename }}
           if-no-files-found: error
 
   upload-coverage-badge:


### PR DESCRIPTION
Fix ci for uploading badges to pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved CI workflow for better handling of coverage badges.
  - Coverage badges now generated and moved to the `docs` directory.
  - Deployment to GitHub Pages and badge uploads are now restricted to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->